### PR TITLE
Fix LiveKit token 400 by sanitizing identity

### DIFF
--- a/src/Dumcsi.Frontend/src/services/livekitService.ts
+++ b/src/Dumcsi.Frontend/src/services/livekitService.ts
@@ -16,7 +16,7 @@ import type { EntityId } from './types';
 export interface LiveKitTokenRequest {
     roomName: string;
     participantName: string;
-    role?: number; // 0=Subscriber, 1=Publisher, 2=Admin  
+    role?: number; // 0=Subscriber, 1=Publisher, 2=Admin
     tokenExpirationMinutes?: number;
 }
 
@@ -25,7 +25,7 @@ export interface LiveKitServerInfo {
     version: string;
 }
 
-class LiveKitService {
+export class LiveKitService {
     private room: Room | null = null;
     private isConnected = false;
     private screenShareTrack: LocalTrackPublication | null = null;


### PR DESCRIPTION
## Summary
- export LiveKitService class to allow type generation
- sanitize username when joining a voice channel to avoid invalid identities
- avoid reconnecting to LiveKit when user isn't in a voice channel to stop token spam

## Testing
- `npm run build`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689685078d8c832d88a2a836bf78fabe