### PR TITLE
Fix LiveKit token request casing to match backend

### DIFF
--- a/src/Dumcsi.Frontend/src/services/livekitService.ts
+++ b/src/Dumcsi.Frontend/src/services/livekitService.ts
@@ -13,11 +13,15 @@ import {
 import api from './api';
 import type { EntityId } from './types';
 
+// Note: PascalCase property names are required by the backend
+// LiveKit controller. Using camelCase here would result in
+// a 400 Bad Request response because the properties would not
+// bind correctly on the server.
 export interface LiveKitTokenRequest {
-    roomName: string;
-    participantName: string;
-    role?: number; // 0=Subscriber, 1=Publisher, 2=Admin
-    tokenExpirationMinutes?: number;
+    RoomName: string;
+    ParticipantName: string;
+    Role?: number; // 0=Subscriber, 1=Publisher, 2=Admin
+    TokenExpirationMinutes?: number;
 }
 
 export interface LiveKitServerInfo {
@@ -44,12 +48,14 @@ export class LiveKitService {
     }
 
     async getAccessToken(roomName: string, participantName: string): Promise<string> {
-        const response = await api.post('/LiveKit/token', {
-            roomName,
-            participantName,
-            role: 1, // Publisher role to allow screen sharing
-            tokenExpirationMinutes: 360
-        });
+        const request: LiveKitTokenRequest = {
+            RoomName: roomName,
+            ParticipantName: participantName,
+            Role: 1, // Publisher role to allow screen sharing
+            TokenExpirationMinutes: 360
+        };
+
+        const response = await api.post('/LiveKit/token', request);
         return response.data.data.token; // Extract token from ApiResponse wrapper
     }
 


### PR DESCRIPTION
## Summary
- use PascalCase keys in LiveKit token request so backend model binding succeeds

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68968e265568832d92ed331c097e5fc2